### PR TITLE
Remove google import

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-registry=https://pkgs.dev.azure.com/osapiens/_packaging/osapiens/npm/registry/ 
-                        
-always-auth=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+registry=https://pkgs.dev.azure.com/osapiens/_packaging/osapiens/npm/registry/ 
+                        
+always-auth=true

--- a/src/scss/common.scss
+++ b/src/scss/common.scss
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css?family=Inter:400,500,700&display=swap');
-
 $fontfamily: 'Inter', sans-serif;  
 
 @mixin message-bubble($color, $textColor, $borderRadius: 15px) {


### PR DESCRIPTION
 Removing Google Fonts import because rasa-webchat has an embedded GDPR compliance incident as it is importing fonts from https://fonts.googleapis.com
